### PR TITLE
Add strict credo step to GH actions workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -75,6 +75,8 @@ jobs:
       run: mix local.rebar --force
     - name: Install Dependencies
       run: mix do deps.get, compile
+    - name: Run code analysis
+      run: mix credo --strict
     - name: Report coverage
       run: mix coveralls.github
     - name: Check documentation coverage


### PR DESCRIPTION
Since it's already part of the dev dependencies we should utilize it for CI as well.