### PR TITLE
Adds missing meta data to Entry, Asset and ContentType responses

### DIFF
--- a/lib/contentful/content_type.ex
+++ b/lib/contentful/content_type.ex
@@ -8,6 +8,7 @@ defmodule Contentful.ContentType do
   alias Contentful.{ContentType, SysData}
 
   defstruct [
+    :id,
     :name,
     :description,
     :display_field,
@@ -20,6 +21,7 @@ defmodule Contentful.ContentType do
   """
 
   @type t :: %ContentType{
+          id: String.t(),
           name: String.t(),
           display_field: String.t(),
           description: String.t(),

--- a/lib/contentful/sys_data.ex
+++ b/lib/contentful/sys_data.ex
@@ -5,13 +5,15 @@ defmodule Contentful.SysData do
 
   See the [official documentation for more information](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/locales).
   """
-  defstruct [:id, :revision, :version, :created_at, :updated_at]
+  defstruct [:id, :revision, :version, :created_at, :updated_at, locale: nil]
 
   @type t :: %Contentful.SysData{
           id: String.t(),
           revision: integer() | nil,
           version: integer() | nil,
           created_at: String.t() | nil,
-          updated_at: String.t() | nil
+          updated_at: String.t() | nil,
+          # NOTE: locale string only exists in entries and assets
+          locale: String | nil
         }
 end

--- a/lib/contentful/sys_data.ex
+++ b/lib/contentful/sys_data.ex
@@ -1,8 +1,6 @@
 defmodule Contentful.SysData do
-  alias Contentful.ContentType
-
   @moduledoc """
-  The SysData represents internal additional data for Contetnful API objects, usually found in the
+  The SysData represents internal additional data for Contentful API objects, usually found in the
   "sys" part of the response objects. It's also referred to as "common properties".
 
   See the [official documentation for more information](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/locales).
@@ -11,13 +9,15 @@ defmodule Contentful.SysData do
 
   @type t :: %Contentful.SysData{
           id: String.t(),
+          # NOTE Entries, assets, content types
           revision: integer() | nil,
           version: integer() | nil,
-          created_at: String.t(),
+          # NOTE: timestamps exist for Asset, Entry and ContentType
+          created_at: String.t() | nil,
           updated_at: String.t() | nil,
           # NOTE: locale string only exists in entries and assets
           locale: String | nil,
           # NOTE: ContentType only exists for entries
-          content_type: %ContentType{} | nil
+          content_type: String.t() | nil
         }
 end

--- a/lib/contentful/sys_data.ex
+++ b/lib/contentful/sys_data.ex
@@ -13,7 +13,7 @@ defmodule Contentful.SysData do
           id: String.t(),
           revision: integer() | nil,
           version: integer() | nil,
-          created_at: String.t() | nil,
+          created_at: String.t(),
           updated_at: String.t() | nil,
           # NOTE: locale string only exists in entries and assets
           locale: String | nil,

--- a/lib/contentful/sys_data.ex
+++ b/lib/contentful/sys_data.ex
@@ -1,11 +1,13 @@
 defmodule Contentful.SysData do
+  alias Contentful.ContentType
+
   @moduledoc """
   The SysData represents internal additional data for Contetnful API objects, usually found in the
   "sys" part of the response objects. It's also referred to as "common properties".
 
   See the [official documentation for more information](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/locales).
   """
-  defstruct [:id, :revision, :version, :created_at, :updated_at, locale: nil]
+  defstruct [:id, :revision, :version, :created_at, :updated_at, locale: nil, content_type: nil]
 
   @type t :: %Contentful.SysData{
           id: String.t(),
@@ -14,6 +16,8 @@ defmodule Contentful.SysData do
           created_at: String.t() | nil,
           updated_at: String.t() | nil,
           # NOTE: locale string only exists in entries and assets
-          locale: String | nil
+          locale: String | nil,
+          # NOTE: ContentType only exists for entries
+          content_type: %ContentType{} | nil
         }
 end

--- a/lib/contentful/sys_data.ex
+++ b/lib/contentful/sys_data.ex
@@ -5,11 +5,13 @@ defmodule Contentful.SysData do
 
   See the [official documentation for more information](https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/locales).
   """
-  defstruct [:id, :revision, :version]
+  defstruct [:id, :revision, :version, :created_at, :updated_at]
 
   @type t :: %Contentful.SysData{
           id: String.t(),
           revision: integer() | nil,
-          version: integer() | nil
+          version: integer() | nil,
+          created_at: String.t() | nil,
+          updated_at: String.t() | nil
         }
 end

--- a/lib/contentful_delivery/assets.ex
+++ b/lib/contentful_delivery/assets.ex
@@ -2,7 +2,46 @@ defmodule Contentful.Delivery.Assets do
   @moduledoc """
   Deals with the loading of assets from a given `Contentful.Space`
 
-  https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/assets
+  See https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/assets.end
+
+  ## Simple asset calls
+
+  A `Contentful.Asset` can be retrieved by its `asset_id`:
+
+    import Contentful.Query
+    alias Contentful.Asset
+    alias Contentful.Delivery.Assets
+
+    {:ok, %Asset{id: "my_asset_id"}} = Assets |> fetch_one("my_asset_id")
+
+  or just as a collection:
+
+    import Contentful.Query
+    alias Contentful.Asset
+    alias Contentful.Delivery.Assets
+
+    {:ok, [%Asset{id: "my_asset_id"} | _ ]} = Assets |> fetch_all
+
+  ## Resolving assets from entries
+
+  In the case of inclusion of assets with entries, see the docs for `Contentful.Entries` to see how to resolve assets
+  from entries.
+
+  ## Accessing common resource attributes
+
+  A `Contentful.Asset` embeds `Contentful.SysData` with extra information about the entry:
+
+    import Contentful.Query
+    alias Contentful.Asset
+    alias Contentful.Delivery.Assets
+
+    {:ok, asset} = Assets |> fetch_one("my_asset_id")
+
+    "my_asset_id" = asset.id
+    "<a timestamp for updated_at>" = asset.sys.updated_at
+    "<a timestamp for created_at>" = asset.sys.created_at
+    "<a locale string>" = asset.sys.locale
+
   """
 
   alias Contentful.{Asset, Queryable, SysData}

--- a/lib/contentful_delivery/assets.ex
+++ b/lib/contentful_delivery/assets.ex
@@ -30,14 +30,26 @@ defmodule Contentful.Delivery.Assets do
               "url" => url
             }
           } = fields,
-        "sys" => %{"id" => id, "revision" => rev}
+        "sys" => %{
+          "id" => id,
+          "revision" => rev,
+          "createdAt" => created_at,
+          "updatedAt" => updated_at,
+          "locale" => locale
+        }
       }) do
     # title and description optional fields for assets
     title = fields |> Map.get("title", nil)
     desc = fields |> Map.get("description", nil)
 
     asset = %Asset{
-      sys: %SysData{id: id, revision: rev},
+      sys: %SysData{
+        id: id,
+        revision: rev,
+        created_at: created_at,
+        updated_at: updated_at,
+        locale: locale
+      },
       fields: %Asset.Fields{
         title: title,
         description: desc,

--- a/lib/contentful_delivery/content_types.ex
+++ b/lib/contentful_delivery/content_types.ex
@@ -29,7 +29,12 @@ defmodule Contentful.Delivery.ContentTypes do
         "name" => name,
         "description" => description,
         "displayField" => display_field,
-        "sys" => %{"id" => id, "revision" => rev},
+        "sys" => %{
+          "id" => id,
+          "revision" => rev,
+          "updatedAt" => updated_at,
+          "createdAt" => created_at
+        },
         "fields" => fields
       }) do
     {:ok,
@@ -38,7 +43,7 @@ defmodule Contentful.Delivery.ContentTypes do
        description: description,
        display_field: display_field,
        fields: Enum.map(fields, &build_field/1),
-       sys: %SysData{id: id, revision: rev}
+       sys: %SysData{id: id, revision: rev, updated_at: updated_at, created_at: created_at}
      }}
   end
 

--- a/lib/contentful_delivery/content_types.ex
+++ b/lib/contentful_delivery/content_types.ex
@@ -1,6 +1,41 @@
 defmodule Contentful.Delivery.ContentTypes do
   @moduledoc """
   Provides functions around reading content types from a given `Contentful.Space`
+
+  See https://www.contentful.com/developers/docs/references/content-delivery-api/#/reference/content-types/content-type
+
+  ## Simple calls
+
+  Fetching a single content type is straight forward:
+
+    import Contentful.Query
+    alias Contentful.ContentType
+    alias Contentful.Delivery.ContentTypes
+
+    {:ok, %ContentType{id: "my_content_type_id"}} = ContentTypes |> fetch_one("my_content_type_id")
+
+  Fetching multiple content types is also possible:
+
+    import Contentful.Query
+    alias Contentful.ContentType
+    alias Contentful.Delivery.ContentTypes
+
+    {:ok, [%ContentType{id: "my_content_type_id"} | _ ]} = ContentTypes |> fetch_all
+
+  ## Accessing common resource attributes
+
+  A `Contentful.ContentType` embeds `Contentful.SysData` with extra information about the entry:
+
+    import Contentful.Query
+    alias Contentful.ContentType
+    alias Contentful.Delivery.ContentTypes
+
+    {:ok, content_type} = ContentTypes |> fetch_one("my_content_type_id")
+
+    "my_content_type_id" = content_type.id
+    "<a timestamp for updated_at>" = content_type.sys.updated_at
+    "<a timestamp for created_at>" = content_type.sys.created_at
+
   """
 
   alias Contentful.{ContentType, Queryable, SysData}

--- a/lib/contentful_delivery/content_types.ex
+++ b/lib/contentful_delivery/content_types.ex
@@ -39,11 +39,12 @@ defmodule Contentful.Delivery.ContentTypes do
       }) do
     {:ok,
      %ContentType{
+       id: id,
        name: name,
        description: description,
        display_field: display_field,
        fields: Enum.map(fields, &build_field/1),
-       sys: %SysData{id: id, revision: rev, updated_at: updated_at, created_at: created_at}
+       sys: %SysData{revision: rev, updated_at: updated_at, created_at: created_at}
      }}
   end
 

--- a/lib/contentful_delivery/entries.ex
+++ b/lib/contentful_delivery/entries.ex
@@ -100,7 +100,7 @@ defmodule Contentful.Delivery.Entries do
           "id" => id,
           "revision" => rev,
           "updatedAt" => updated_at,
-          "created_at" => created_at,
+          "createdAt" => created_at,
           "locale" => locale
         }
       }) do

--- a/lib/contentful_delivery/entries.ex
+++ b/lib/contentful_delivery/entries.ex
@@ -47,7 +47,7 @@ defmodule Contentful.Delivery.Entries do
 
   """
 
-  alias Contentful.{Asset, Entry, Queryable, SysData}
+  alias Contentful.{Asset, ContentType, Entry, Queryable, SysData}
   alias Contentful.Delivery.Assets
   alias Contentful.Entry.AssetResolver
 
@@ -101,7 +101,8 @@ defmodule Contentful.Delivery.Entries do
           "revision" => rev,
           "updatedAt" => updated_at,
           "createdAt" => created_at,
-          "locale" => locale
+          "locale" => locale,
+          "contentType" => %{"sys" => content_type_id}
         }
       }) do
     {:ok,
@@ -112,7 +113,8 @@ defmodule Contentful.Delivery.Entries do
          revision: rev,
          locale: locale,
          updated_at: updated_at,
-         created_at: created_at
+         created_at: created_at,
+         content_type: %ContentType{id: content_type_id}
        }
      }}
   end

--- a/lib/contentful_delivery/entries.ex
+++ b/lib/contentful_delivery/entries.ex
@@ -96,12 +96,24 @@ defmodule Contentful.Delivery.Entries do
   """
   def resolve_entity_response(%{
         "fields" => fields,
-        "sys" => %{"id" => id, "revision" => rev}
+        "sys" => %{
+          "id" => id,
+          "revision" => rev,
+          "updatedAt" => updated_at,
+          "created_at" => created_at,
+          "locale" => locale
+        }
       }) do
     {:ok,
      %Entry{
        fields: fields,
-       sys: %SysData{id: id, revision: rev}
+       sys: %SysData{
+         id: id,
+         revision: rev,
+         locale: locale,
+         updated_at: updated_at,
+         created_at: created_at
+       }
      }}
   end
 

--- a/lib/contentful_delivery/entries.ex
+++ b/lib/contentful_delivery/entries.ex
@@ -44,6 +44,23 @@ defmodule Contentful.Delivery.Entries do
 
       Entries |> include |> stream |> Stream.flat_map(fn entry -> entry.assets end) |> Enum.take(2)
 
+  ## Accessing common resource attributes
+
+  Entries embed `Contentful.SysData` with extra information about the entry:
+
+    import Contentful.Query
+    alias Contentful.{ContentType, Entry, SysData}
+    alias Contentful.Delivery.Entries
+
+    {:ok, entry} = Entries |> fetch_one("my_entry_id")
+
+    "my_entry_id" = entry.id
+    "<a timestamp for updated_at>" = entry.sys.updated_at
+    "<a timestamp for created_at>" = entry.sys.created_at
+    "<a locale string>" = entry.sys.locale
+    %ContentType{id: "the_associated_content_type_id"} =  entry.sys.content_type
+
+
 
   """
 

--- a/lib/contentful_delivery/entries.ex
+++ b/lib/contentful_delivery/entries.ex
@@ -60,8 +60,6 @@ defmodule Contentful.Delivery.Entries do
     "<a locale string>" = entry.sys.locale
     %ContentType{id: "the_associated_content_type_id"} =  entry.sys.content_type
 
-
-
   """
 
   alias Contentful.{Asset, ContentType, Entry, Queryable, SysData}

--- a/test/contentful_delivery/assets_test.exs
+++ b/test/contentful_delivery/assets_test.exs
@@ -1,6 +1,6 @@
 defmodule Contentful.Delivery.AssetsTest do
   use ExUnit.Case
-  alias Contentful.Asset
+  alias Contentful.{Asset, SysData}
   alias Contentful.Delivery.Assets
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
@@ -23,6 +23,17 @@ defmodule Contentful.Delivery.AssetsTest do
     test "fetches a single asset by it's id from a space" do
       use_cassette "single asset" do
         {:ok, %Asset{sys: %{id: @asset_id}}} = Assets |> fetch_one(@asset_id, @space_id)
+      end
+    end
+
+    test "contains the meta information in sys" do
+      use_cassette "single asset" do
+        {:ok, %Asset{sys: %SysData{id: @asset_id, updated_at: _, created_at: _, locale: _} = sys}} =
+          Assets |> fetch_one(@asset_id, @space_id)
+
+        assert sys.created_at
+        assert sys.updated_at
+        assert sys.locale
       end
     end
   end

--- a/test/contentful_delivery/content_types_test.exs
+++ b/test/contentful_delivery/content_types_test.exs
@@ -60,5 +60,15 @@ defmodule Contentful.Delivery.ContentTypesTest do
           ContentTypes |> fetch_one("product", @space_id, @env, @access_token)
       end
     end
+
+    test "provides meta information" do
+      use_cassette "single_content_type" do
+        {:ok, %ContentType{id: "product", sys: %SysData{updated_at: _, created_at: _} = sys}} =
+          ContentTypes |> fetch_one("product", @space_id, @env, @access_token)
+
+        assert sys.updated_at
+        assert sys.created_at
+      end
+    end
   end
 end

--- a/test/contentful_delivery/entries_test.exs
+++ b/test/contentful_delivery/entries_test.exs
@@ -2,7 +2,7 @@ defmodule Contentful.Delivery.EntriesTest do
   use ExUnit.Case
 
   alias Contentful.Delivery.Entries
-  alias Contentful.{Entry, Space, SysData}
+  alias Contentful.{ContentType, Entry, Space, SysData}
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
@@ -32,12 +32,22 @@ defmodule Contentful.Delivery.EntriesTest do
 
     test "provides meta information" do
       use_cassette "single entry" do
-        {:ok, %Entry{sys: %SysData{updated_at: _, created_at: _, locale: _} = sys}} =
-          Entries |> fetch_one(@entry_id, @space_id, @env, @access_token)
+        {:ok,
+         %Entry{
+           sys:
+             %SysData{
+               updated_at: _,
+               created_at: _,
+               locale: _,
+               content_type: %ContentType{id: content_type_id}
+             } = sys
+         }} = Entries |> fetch_one(@entry_id, @space_id, @env, @access_token)
 
         assert sys.updated_at
         assert sys.created_at
         assert sys.locale
+
+        assert content_type_id
       end
     end
   end

--- a/test/contentful_delivery/entries_test.exs
+++ b/test/contentful_delivery/entries_test.exs
@@ -2,7 +2,7 @@ defmodule Contentful.Delivery.EntriesTest do
   use ExUnit.Case
 
   alias Contentful.Delivery.Entries
-  alias Contentful.{ContentType, Entry, Space, SysData}
+  alias Contentful.{Entry, Space, SysData}
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
@@ -39,7 +39,7 @@ defmodule Contentful.Delivery.EntriesTest do
                updated_at: _,
                created_at: _,
                locale: _,
-               content_type: %ContentType{id: content_type_id}
+               content_type: content_type_id
              } = sys
          }} = Entries |> fetch_one(@entry_id, @space_id, @env, @access_token)
 

--- a/test/contentful_delivery/entries_test.exs
+++ b/test/contentful_delivery/entries_test.exs
@@ -29,6 +29,17 @@ defmodule Contentful.Delivery.EntriesTest do
           Entries |> fetch_one(@entry_id, @space_id, @env, @access_token)
       end
     end
+
+    test "provides meta information" do
+      use_cassette "single entry" do
+        {:ok, %Entry{sys: %SysData{updated_at: _, created_at: _, locale: _} = sys}} =
+          Entries |> fetch_one(@entry_id, @space_id, @env, @access_token)
+
+        assert sys.updated_at
+        assert sys.created_at
+        assert sys.locale
+      end
+    end
   end
 
   describe ".fetch_all" do


### PR DESCRIPTION
This will add missing meta information back into the resolved responses:

## Assets

```elixir
import Contentful.Query
alias Contentful.Asset
alias Contentful.Delivery.Assets

{:ok, asset} = Assets |> fetch_one("my_asset_id")

"my_asset_id" = asset.id
"<a timestamp for updated_at>" = asset.sys.updated_at
"<a timestamp for created_at>" = asset.sys.created_at
"<a locale string>" = asset.sys.locale
```

## Entries

```elixir
import Contentful.Query
alias Contentful.{ContentType, Entry, SysData}
alias Contentful.Delivery.Entries

{:ok, entry} = Entries |> fetch_one("my_entry_id")

"my_entry_id" = entry.id
"<a timestamp for updated_at>" = entry.sys.updated_at
"<a timestamp for created_at>" = entry.sys.created_at
"<a locale string>" = entry.sys.locale
%ContentType{id: "the_associated_content_type_id"} =  entry.sys.content_type
```

## ContentTypes
```elixir
import Contentful.Query
alias Contentful.ContentType
alias Contentful.Delivery.ContentTypes

{:ok, content_type} = ContentTypes |> fetch_one("my_content_type_id")

"my_content_type_id" = content_type.id
"<a timestamp for updated_at>" = content_type.sys.updated_at
"<a timestamp for created_at>" = content_type.sys.created_at
```

## Why is the `id` not part of `sys`?

Because I am lazy and the id is most likely just important enough to warrant being access by `entity.id` instead of `entity.sys.id`. I am open to feedback here :wink: 

Shoutout to @OldhamMade for bringing this to my attention in #44.

fixes #44.