### PR TITLE
Handle bitstring case when resolving assets

### DIFF
--- a/lib/contentful/entry/asset_resolver.ex
+++ b/lib/contentful/entry/asset_resolver.ex
@@ -33,6 +33,15 @@ defmodule Contentful.Entry.AssetResolver do
     acc
   end
 
+  # match taglists which have the form ["Hello", "world"]
+  defp find_in_data(
+         {_field_name, [head | _tail]},
+         acc
+       )
+       when is_bitstring(head) do
+    acc
+  end
+
   defp find_in_data(
          {_field_name, list},
          acc

--- a/test/contentful/entry/asset_resolver_test.exs
+++ b/test/contentful/entry/asset_resolver_test.exs
@@ -117,5 +117,16 @@ defmodule Contentful.Entry.AssetResolverTest do
       ["5ECf6ltDUOnX441PtBR8Wk", "577fpmbIfYD71VCjCpYA84"] =
         entry |> AssetResolver.find_linked_asset_ids()
     end
+
+    test "does not choke up on contentful taglist (list of bitstrings)" do
+      entry = %Entry{
+        assets: [],
+        fields: %{
+          "my-tags" => ["hello", "world"]
+        }
+      }
+
+      [] = entry |> AssetResolver.find_linked_asset_ids()
+    end
   end
 end


### PR DESCRIPTION
Hello!

We are using this fantastic app in one of our projects. Our Client uses Contentful - Tags, which get serialized into json as arrays. 

Example:
```elixir
[snip]

"fields": {
        "id": 3,
        "title": "Digital Workforces",
        "tags": [
          "Automation",
          "AI",
          "Digital"
        ],
        "details": "Work Smarter. (...)",
}

[snip]
```


This causes the asset resolver to fail with `(Protocol.UndefinedError) protocol Enumerable not implemented for "Automation" of type BitString.`. The AssetResolver tries to resolve assets within the tags-array. This is due to the matching `Contentful.Entry.AssetResolver.find_in_data/2` clause:

```
  defp find_in_data(
         {_field_name, list},
         acc
       )
       when is_list(list) do
    list |> Enum.flat_map(fn fields -> fields |> Enum.reduce(acc, &find_in_data/2) end)
  end
```

We fixed this by adding an additional clause where we check if the list head is indeed a Bitstring and skip this field.





Signed-off-by: Andreas Solleder <sollederandreas@gmail.com>