### PR TITLE
[ACT-2416][ACT-2417][ACT-2418] add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -6,6 +6,9 @@ on:
   # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   approval:
     runs-on: ubuntu-20.04

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}}


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to both GitHub Actions workflows so `GITHUB_TOKEN` defaults to read-only.
- `elixir.yml` only runs tests and pushes coverage to coveralls.io — no repo writes from `GITHUB_TOKEN`.
- `dependabot-auto-approve.yml` already uses a separate `BOT_TOKEN` PAT for the approval/merge action, so the workflow's own token only needs to check out code.

Resolves [ACT-2416], [ACT-2417], [ACT-2418].

🤖 Generated with [Claude Code](https://claude.com/claude-code)