### PR TITLE
pin Elixir CI to ubuntu-22.04

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     name: OTP ${{matrix.otp}} | Elixir ${{matrix.elixir}}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -48,7 +48,7 @@ jobs:
 
   quality:
     name: Code quality checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Summary

- `erlef/setup-beam@v1.15` only recognizes `ubuntu18/20/22` ImageOS values; `ubuntu-latest` now resolves to `ubuntu-24.04`, causing every Elixir CI job to fail at the setup-beam step with: *Tried to map a target OS from env. variable 'ImageOS' (got ubuntu24), but failed*.
- Pin both jobs to `ubuntu-22.04` to keep the current OTP 24/25 + Elixir 1.13/1.14 matrix working. Bumping setup-beam was the alternative, but newer versions don't ship the older OTP/Elixir combos in this matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)